### PR TITLE
Add a function overload type for filter methods

### DIFF
--- a/src/list.spec.ts
+++ b/src/list.spec.ts
@@ -20,6 +20,10 @@ describe('List', () => {
         .filter(x => x > 5)
         .toArray(),
     ).toEqual([10, 20])
+
+    const things = List<unknown>(1, 2, 4, 'a', 'b')
+    const filteredThings = things.filter((n): n is number => typeof n === 'number')
+    expect(filteredThings.toArray()).toEqual([1, 2, 4])
   })
 
   it('maps over a list', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -2,20 +2,21 @@ import { Option } from './option'
 import { Monoid } from './monoid'
 
 export interface List<T> extends Monoid<List<T>> {
-  toArray: () => T[]
-  toString: () => string
-  inspect: () => string
-  map: <K>(fn: (item: T) => K) => List<K>
-  filter: (fn: (el: T) => boolean) => List<T>
-  length: () => number
-  flatMap: <K>(fn: (item: T) => List<K>) => List<K>
-  chain: <K>(fn: (item: T) => List<K>) => List<K>
-  fold: <K>(initial: K, fn: (acc: K, el: T) => K) => K
-  head: () => T | undefined
-  headOption: () => Option<T>
-  tail: () => List<T>
-  find: (p: (item: T) => boolean) => Option<T>
-  contains: (p: (item: T) => boolean) => boolean
+  toArray(): T[]
+  toString(): string
+  inspect(): string
+  map<K>(fn: (item: T) => K): List<K>
+  filter<K extends T>(fn: (el: T) => el is K): List<K>
+  filter(fn: (el: T) => boolean): List<T>
+  length(): number
+  flatMap<K>(fn: (item: T) => List<K>): List<K>
+  chain<K>(fn: (item: T) => List<K>): List<K>
+  fold<K>(initial: K, fn: (acc: K, el: T) => K): K
+  head(): T | undefined
+  headOption(): Option<T>
+  tail(): List<T>
+  find(p: (item: T) => boolean): Option<T>
+  contains(p: (item: T) => boolean): boolean
 }
 
 export function List<T>(...items: T[]): List<T> {

--- a/src/option.spec.ts
+++ b/src/option.spec.ts
@@ -111,6 +111,12 @@ describe('Option', () => {
       expect(option.filter(v => v.length < 10).type).toBe('some')
     })
 
+    it('narrows a to a type based on a type guard', () => {
+      const result = Option<string | number>('a').filter((n): n is number => typeof n === 'number')
+
+      expect(result.type).toBe('none')
+    })
+
     it('implements a getOrElse method', () => {
       const option = Some('hello')
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -2,17 +2,18 @@ import { F, T, returnVoid, identity, returnUndefined } from './utils'
 
 export interface Option<T> {
   type: 'some' | 'none'
-  isSome: () => boolean
-  get: () => T | undefined
-  map: <K>(fn: (value: T) => K) => Option<K>
-  flatMap: <K>(fn: (value: T) => Option<K>) => Option<K>
-  chain: <K>(fn: (value: T) => Option<K>) => Option<K>
-  fold: <K>(ifEmpty: () => K, fn: (value: T) => K) => K
-  filter: (fn: (value: T) => boolean) => Option<T>
-  getOrElse: <K>(alternative: K) => T | K
-  toString: () => string
-  inspect: () => string
-  forEach: (fn: (value: T) => any) => void
+  isSome(): boolean
+  get(): T | undefined
+  map<K>(fn: (value: T) => K): Option<K>
+  flatMap<K>(fn: (value: T) => Option<K>): Option<K>
+  chain<K>(fn: (value: T) => Option<K>): Option<K>
+  fold<K>(ifEmpty: () => K, fn: (value: T) => K): K
+  filter<S extends T>(fn: (value: T) => value is S): Option<S>
+  filter(fn: (value: T) => boolean): Option<T>
+  getOrElse<K>(alternative: K): T | K
+  toString(): string
+  inspect(): string
+  forEach(fn: (value: T) => any): void
 }
 
 export interface Some<T> extends Option<T> {
@@ -22,7 +23,7 @@ export interface Some<T> extends Option<T> {
 
 export function Some<T>(value: T): Some<T> {
   const inspect = () => `Some(${JSON.stringify(value)})`
-  const flatMap = fn => fn(value)
+  const flatMap = <K>(fn: (value: T) => Option<K>) => fn(value)
 
   return {
     type: 'some',
@@ -92,7 +93,7 @@ export interface OptionFactory {
       MaybeOption<T3>,
       MaybeOption<T4>,
       MaybeOption<T5>,
-      MaybeOption<T6>
+      MaybeOption<T6>,
     ],
   ): Option<[T1, T2, T3, T4, T5, T6]>
   all<T1, T2, T3, T4, T5, T6, T7>(
@@ -103,7 +104,7 @@ export interface OptionFactory {
       MaybeOption<T4>,
       MaybeOption<T5>,
       MaybeOption<T6>,
-      MaybeOption<T7>
+      MaybeOption<T7>,
     ],
   ): Option<[T1, T2, T3, T4, T5, T6, T7]>
 


### PR DESCRIPTION
This allows narrowing the type of a context based on type guards:

E.g.

```ts
const thing: Option<unknown>
const filteredThing = thing.filter(isNumber) // Option<number>
```
